### PR TITLE
Use express-ws as an alternative to raw ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "ws": "*"
+    "express-ws": "*"
   },
   "devDependencies": {
     "grunt": "~0.4",


### PR DESCRIPTION
This is really just a quick test to ensure that passing app into plugin servers, fedwiki/wiki-server#115, together with starting the plugin servers when in farm mode, fedwiki/wiki#73, work together in the desired way.