### PR TITLE
Resolving websocket usage in farm mode

### DIFF
--- a/client/linkmap.coffee
+++ b/client/linkmap.coffee
@@ -11,55 +11,56 @@ linkmap = {}
 
 # {nodes: [{name: string, group: 1}] links: [{source: 0, target: 33, value: 6}]}
 forceData = ->
-	nodes = []
-	links = []
-	nodeNum = {}
-	nodeGroup = {}
-	for div in $('.page')
-		nodeGroup[div.id] = 1
-	for slug of linkmap
-		nodeNum[slug] = nodes.length
-		nodes.push {name: slug, group: nodeGroup[slug] || 3}
-	for slug, slugs of linkmap
-		source = nodeNum[slug]
-		for link, i in slugs
-			if i<4 and (target = nodeNum[link])?
-				links.push({source, target, value: 6})
-	{nodes, links}
+  nodes = []
+  links = []
+  nodeNum = {}
+  nodeGroup = {}
+  for div in $('.page')
+    nodeGroup[div.id] = 1
+  for slug of linkmap
+    nodeNum[slug] = nodes.length
+    nodes.push {name: slug, group: nodeGroup[slug] || 3}
+  for slug, slugs of linkmap
+    source = nodeNum[slug]
+    for link, i in slugs
+      if i<4 and (target = nodeNum[link])?
+        links.push({source, target, value: 6})
+  {nodes, links}
 
 stats =  ->
-	force = forceData()
-	"#{force.nodes.length} nodes, #{force.links.length} links"
+  force = forceData()
+  "#{force.nodes.length} nodes, #{force.links.length} links"
 
 
 emit = ($item, item) ->
-	$item.css "background-color", "#eee"
-	$item.css "padding", 5
-	$item.append """<p>Starting Linkmap</p>"""
+  $item.css "background-color", "#eee"
+  $item.css "padding", 5
+  $item.append """<p>Starting Linkmap</p>"""
 
 bind = ($item, item) ->
-	$item.addClass 'force-source'
-	$item.get(0).forceData = forceData
-	$item.dblclick -> wiki.dialog "linkdata", "<pre>#{linkdata}</pre>"
+  $item.addClass 'force-source'
+  $item.get(0).forceData = forceData
+  $item.dblclick -> wiki.dialog "linkdata", "<pre>#{linkdata}</pre>"
 
-	$page = $item.parents('.page:first')
-	host = $page.data('site') or location.host
-	host = location.host if host is 'origin' or host is 'local'
-	socket = new WebSocket("ws://#{host}/plugin/linkmap")
+  $page = $item.parents('.page:first')
+  server = $page.data('site') or location.host
+  server = location.host if host is 'origin' or host is 'local'
+  host = server.split(':')[0]
+  socket = new WebSocket("ws://#{server}/plugin/linkmap/#{host}")
 
-	progress = (m) ->
-		$item.append $ "<p>Linkmap #{m}</p>"
+  progress = (m) ->
+    $item.append $ "<p>Linkmap #{m}</p>"
 
-	socket.onopen = ->
-	  progress "opened"
+  socket.onopen = ->
+    progress "opened"
 
-	socket.onmessage = (e) ->
-	  linkmap = JSON.parse linkdata = e.data
-	  progress stats()
-	  socket.close()
+  socket.onmessage = (e) ->
+    linkmap = JSON.parse linkdata = e.data
+    progress stats()
+    socket.close()
 
-	socket.onclose = ->
-	  progress "closed"
+  socket.onclose = ->
+    progress "closed"
 
 
 window.plugins.linkmap = {emit, bind}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "ws": "*"
+    "express-ws": "*"
   },
   "devDependencies": {
     "grunt": "~0.4",

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -6,50 +6,52 @@
 ###
 
 fs = require 'fs'
-
-linkmap = {}
-
-asSlug = (name) ->
-  name.replace(/\s/g, '-').replace(/[^A-Za-z0-9-]/g, '').toLowerCase()
-
-fetchPage = (path, done) ->
-  text = fs.readFile path, 'utf8', (err, text) ->
-    return console.log ['linkmap fetchPage error', path, err] if err
-    done JSON.parse text
-
-findLinks = (page) ->
-  unique = {}
-  for item in page.story || []
-    links = switch item?.type
-      when 'paragraph' then item.text.match /\[\[([^\]]+)\]\]/g
-    if links
-      for link in links
-        [match, title] = link.match /\[\[([^\]]+)\]\]/
-        unique[asSlug title] = title
-  slug for slug, title of unique
-
-buildmap = (pages) ->
-  fs.readdir pages, (err, names) ->
-    return if err or !names?.length
-    for slug in names
-      console.log 'linkmap (slug): ', slug
-      if slug.match /^[a-z0-9-]+$/
-        do (slug) ->
-          fetchPage "#{pages}/#{slug}", (page) ->
-            linkmap[slug] = findLinks page
+url = require 'url'
 
 
 startServer = (params) ->
   console.log 'linkmap startServer', (k for k,v of params)
+
   app = params.app
   server = params.server
+  linkmap = {}
+
+  asSlug = (name) ->
+    name.replace(/\s/g, '-').replace(/[^A-Za-z0-9-]/g, '').toLowerCase()
+
+  fetchPage = (path, done) ->
+    text = fs.readFile path, 'utf8', (err, text) ->
+      return console.log ['linkmap fetchPage error', path, err] if err
+      done JSON.parse text
+
+  findLinks = (page) ->
+    unique = {}
+    for item in page.story || []
+      links = switch item?.type
+        when 'paragraph' then item.text.match /\[\[([^\]]+)\]\]/g
+      if links
+        for link in links
+          [match, title] = link.match /\[\[([^\]]+)\]\]/
+          unique[asSlug title] = title
+    slug for slug, title of unique
+
+  buildmap = (pages) ->
+    fs.readdir pages, (err, names) ->
+      return if err or !names?.length
+      for slug in names
+        if slug.match /^[a-z0-9-]+$/
+          do (slug) ->
+            fetchPage "#{pages}/#{slug}", (page) ->
+              linkmap[slug] = findLinks page
+
+  host = url.parse(params.argv.url).hostname
+
   expressWs = require('express-ws')(app, server)
 
   buildmap params.argv.db
 
-  app.ws '/plugin/linkmap', (ws, req) ->
+  app.ws "/plugin/linkmap/#{host}", (ws, req) ->
     console.log 'connection established, ready to send'
-    console.log req.session
     ws.send JSON.stringify(linkmap, null, 2), (err) ->
       console.log 'unable to send ws message:', err if err
 


### PR DESCRIPTION
Replaces #6 

As in #6 this uses express-ws rather than raw sockets, we also add the host into the url to make the path for the websocket unique across a wiki farm.

We also move the `linkmap` initialization inside `startServer` to resolve a scope problem - `linkmap` was shared across all the sites with a farm, causing it to grow adding data from each of the sites within the farm as they start.

There are some associated changes need in wiki-server to add back the server as a parameter when starting the plugin server.
